### PR TITLE
some tidying, and fixing #25 from x86 repo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,9 @@ MAINTAINER sparklyballs
 
 # set environment variables
 ARG DEBIAN_FRONTEND="noninteractive"
+ENV XDG_CONFIG_HOME="/config/xdg"
 
-# add sonarr repository
+# add sonarr repository
 RUN \
  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys FDA5DFFC && \
  echo "deb http://apt.sonarr.tv/ master main" > \
@@ -16,16 +17,16 @@ RUN \
 	libcurl3 \
 	nzbdrone && \
 
-# cleanup
+# cleanup
  apt-get clean && \
- rm -rfv \
+ rm -rf \
 	/tmp/* \
 	/var/lib/apt/lists/* \
 	/var/tmp/*
 
-# add local files
+# add local files
 COPY root/ /
 
-# ports and volumes
-VOLUME /config /downloads /tv
+# ports and volumes
 EXPOSE 8989
+VOLUME /config /downloads /tv

--- a/README.md
+++ b/README.md
@@ -65,5 +65,7 @@ Access the webui at `<your-ip>:8989`, for more information check out [Sonarr](ht
 
 ## Changelog
 
++ **23.09.16:** Add cd to /opt fixes redirects with althub (issue #25 on x86 repo)
+, make XDG config environment variable
 + **15.09.16:** Add libcurl3 package.
 + **13.09.16:** Initial Release.

--- a/root/etc/cont-init.d/30-config
+++ b/root/etc/cont-init.d/30-config
@@ -1,8 +1,9 @@
 #!/usr/bin/with-contenv bash
 
 # cleanup pid if it exists
-[[ -e /config/nzbdrone.pid ]] && rm -rf /config/nzbdrone.pid
+[[ -e /config/nzbdrone.pid ]] && \
+	rm -rf /config/nzbdrone.pid
 
 # permissions
-chown -R abc:abc /opt/NzbDrone
-
+chown -R abc:abc \
+	/opt/NzbDrone

--- a/root/etc/services.d/sonarr/run
+++ b/root/etc/services.d/sonarr/run
@@ -2,4 +2,8 @@
 
 umask 0002
 
-XDG_CONFIG_HOME="/config/xdg" exec s6-setuidgid abc mono /opt/NzbDrone/NzbDrone.exe -nobrowser -data=/config
+cd /opt/NzbDrone
+
+exec \
+	s6-setuidgid abc mono NzbDrone.exe \
+	-nobrowser -data=/config


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[![linuxserver.io](https://www.linuxserver.io/wp-content/uploads/2015/06/linuxserver_medium.png)](https://linuxserver.io)

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->

<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->

<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->

<!---  -->
## Thanks, team linuxserver.io
- change working folder with a cd to /opt/nzbdrone before exec in run command
- add exec in run command for more compliance with s6 in general
- make XDG config an environment variable rather than placing in run command
- some tidying of files in general
- linuxserver/sonarr#25
